### PR TITLE
resolves issue 37: fragment listings need separation punctuation

### DIFF
--- a/pn-xslt/metadata-dclp.xsl
+++ b/pn-xslt/metadata-dclp.xsl
@@ -26,9 +26,19 @@
         <tr>
             <th class="rowheader">Fragments</th>
             <td>
-                <xsl:value-of
-                    select="t:teiHeader/t:fileDesc/t:sourceDesc/t:msDesc/t:msIdentifier/t:idno"
-                />
+                <xsl:for-each select="//t:msIdentifier/descendant::t:idno[@type='invNo']">
+                    <xsl:value-of select="."/>
+                    <xsl:if test="position() != last()">
+                        <xsl:choose>
+                            <xsl:when test="substring(., string-length(.), 1) = ';'">
+                                <xsl:text> </xsl:text>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>; </xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:if>
+                </xsl:for-each>
             </td>
         </tr>
 

--- a/pn-xslt/metadata.xsl
+++ b/pn-xslt/metadata.xsl
@@ -716,8 +716,19 @@
                 <xsl:for-each select="$corrtokens">
                   <xsl:variable name="frag" select="."/>
                   <xsl:variable name="xml-id" select="substring-after($frag, '#')"/>
-                  <xsl:value-of select="$context-node[@xml:id=$xml-id]"/>
-                  <xsl:if test="substring-after($corr, normalize-space(.)) != ''">; </xsl:if>
+                  <xsl:variable name="output-node" select="$context-node[@xml:id=$xml-id]"/>
+                  <xsl:value-of select="$output-node"/>
+                  <xsl:if test="substring-after($corr, normalize-space(.)) != ''">
+                    <xsl:choose>
+                      <xsl:when test="substring($output-node, string-length($output-node), 1) = ';'">
+                        <xsl:text> </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:text>; </xsl:text>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                    
+                  </xsl:if>
                 </xsl:for-each>
               </xsl:if>                
             </xsl:variable>


### PR DESCRIPTION
added interstitial punctuation to fragments listing; added handling for intermittent appearance of semicolons in source data for fragment ids so our output looks uniform; applied that fix also to the corresponding fragments listings in custodial events
